### PR TITLE
PowerShell script version of tcx-strip-heart-rate

### DIFF
--- a/tcx-strip-heart-rate.ps1
+++ b/tcx-strip-heart-rate.ps1
@@ -1,0 +1,28 @@
+param ($tcxinputfilename, $tcxoutputfilename)
+
+function Usage()
+{
+  Write-Host "Usage: .\tcx-strip-heart-rate.ps1 tcxinputfilename tcxoutputfilename";
+	exit;
+}
+
+if (-not $tcxinputfilename -or -not $tcxoutputfilename)
+{
+	Usage;
+}
+
+if(-not (Test-Path $tcxinputfilename))
+{
+	Write-Host "Input file $tcxinputfilename does not exist, or is not readable.";
+	Usage;
+}
+
+$xsltfile = Resolve-Path "tcx-strip-heart-rate.xsl";
+$tcxinputfile = Resolve-Path $tcxinputfilename;
+
+New-Item $tcxoutputfilename -type file -force | out-null
+$tcxoutputfile = Resolve-Path $tcxoutputfilename
+
+$xslt = New-Object System.Xml.Xsl.XslCompiledTransform;
+$xslt.Load($xsltfile);
+$xslt.Transform($tcxinputfile, $tcxoutputfile);


### PR DESCRIPTION
Hi Thomas,

This change is a PowerShell script version of tcx-strip-heart-rate for Windows users:
- uses the same XSL file and syntax as the original tcx-strip-heart-rate
- has the advantage that it doesn't require Saxon to be installed to do the XSL Transformation; this is supported through the .Net framework used by PowerShell

Regards,
Peter
