### PR TITLE
Added calories conversion

### DIFF
--- a/nike+totcx.xsl
+++ b/nike+totcx.xsl
@@ -44,6 +44,8 @@
 
 	     <DistanceMeters><xsl:value-of select="runSummary/distance * 1000"/></DistanceMeters>
 
+	     <Calories><xsl:value-of select="runSummary/calories"/></Calories>
+
               <Track>
 
                   <xsl:choose>


### PR DESCRIPTION
I'm using iPod Nano 6th gen and wanted to convert workouts to .tcx files using your great .xsl. Then I'm uploading them to Endomondo.

One thing I missed is calories - they are not converting in nike+totcx.xsl template. It's a simple conversion using one XSL rule. Tested in Endomondo - they accepted my file and showed me the burned calories.

Please update your .xsl or ask me if you need my help.
